### PR TITLE
Fix ray-aabb intersection code and test

### DIFF
--- a/pyrr/geometric_tests.py
+++ b/pyrr/geometric_tests.py
@@ -224,17 +224,18 @@ def are_rays_coincident( ray1, ray2 ):
 @all_parameters_as_numpy_arrays
 def ray_intersect_aabb( ray, aabb ):
     # http://gamedev.stackexchange.com/questions/18436/most-efficient-aabb-vs-ray-collision-algorithms
-    dir_fraction = numpy.divide( 1.0, aabb[ 1 ] )
+    dir_fraction = numpy.divide( 1.0, ray[ 1 ])
 
-    t1 = (aabb[0,0] - ray[0,0]) * dir_fraction[ 0 ];
-    t2 = (aabb[1,0] - ray[0,0]) * dir_fraction[ 0 ];
-    t3 = (aabb[0,1] - ray[0,1]) * dir_fraction[ 1 ];
-    t4 = (aabb[1,1] - ray[0,1]) * dir_fraction[ 1 ];
-    t5 = (aabb[0,2] - ray[0,2]) * dir_fraction[ 2 ];
-    t6 = (aabb[1,2] - ray[0,2]) * dir_fraction[ 2 ];
+    t1 = (aabb[0,0] - ray[0,0]) * dir_fraction[ 0 ]
+    t2 = (aabb[1,0] - ray[0,0]) * dir_fraction[ 0 ]
+    t3 = (aabb[0,1] - ray[0,1]) * dir_fraction[ 1 ]
+    t4 = (aabb[1,1] - ray[0,1]) * dir_fraction[ 1 ]
+    t5 = (aabb[0,2] - ray[0,2]) * dir_fraction[ 2 ]
+    t6 = (aabb[1,2] - ray[0,2]) * dir_fraction[ 2 ]
 
-    tmin = max(max(min(t1, t2), min(t3, t4)), min(t5, t6));
-    tmax = min(min(max(t1, t2), max(t3, t4)), max(t5, t6));
+
+    tmin = max(min(t1, t2), min(t3, t4), min(t5, t6))
+    tmax = min(max(t1, t2), max(t3, t4), max(t5, t6))
 
     # if tmax < 0, ray (line) is intersecting AABB
     # but the whole AABB is behind the ray start
@@ -247,7 +248,9 @@ def ray_intersect_aabb( ray, aabb ):
 
     # t is the distance from the ray point
     # to intersection
-    point = ray[ 0 ] + (ray[ 1 ] * tmin)
+
+    t = abs(tmin)
+    point = ray[ 0 ] + (ray[ 1 ] * t)
     return point
 
 @all_parameters_as_numpy_arrays

--- a/pyrr/test/test_geometric_tests.py
+++ b/pyrr/test/test_geometric_tests.py
@@ -148,26 +148,31 @@ class test_geometric_tests( unittest.TestCase ):
         invalid_intersections()
 
     def test_ray_intersect_aabb( self ):
-        a = numpy.array(
-            [
-                [-1.0,-1.0,-1.0 ],
-                [ 1.0, 1.0, 1.0 ]
-                ]
+        for min_corner, max_corner, origin, direction, expected in (
+            (
+                [-1.0,-1.0,-1.0 ], [ 1.0, 1.0, 1.0 ],
+                [ 0.5, 0.5, 0.0 ], [ 0.0, 0.0,-1.0 ],
+                [ 0.5, 0.5,-1.0 ]
+            ),
+            (
+                [-1.0,-1.0,-1.0 ], [ 1.0, 1.0, 1.0 ],
+                [2.0, 2.0, 2.0 ], [ -1.0, -1.0, -1.0 ],
+                [1.0, 1.0, 1.0],
             )
-        ray = numpy.array(
-            [
-                [ 0.5, 0.5, 5.0 ],
-                [ 0.0, 0.0,-1.0 ]
-                ]
-            )
-        result = gt.ray_intersect_aabb( ray, a )
+                ):
+            aabb = numpy.array( [min_corner, max_corner] )
+            ray = numpy.array( [origin, direction] )
+            result = gt.ray_intersect_aabb( ray, aabb )
 
-        expected = numpy.array( [ 0.5, 0.5,-1.0 ] )
+            expected = numpy.array( expected )
 
-        self.assertTrue(
-            numpy.array_equal( result, expected ),
-            "Ray vs AABB intersection incorrect"
+            self.assertTrue(
+                numpy.array_equal( result, expected ),
+                "Ray vs AABB intersection incorrect: expected %s, got %s" % (
+                    expected, result
+                )
             )
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Before applying this patch one of the tests has been failing:

```
............F....................................
======================================================================
FAIL: test_ray_intersect_aabb (pyrr.test.test_geometric_tests.test_geometric_tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/aa/projects/Pyrr/pyrr/test/test_geometric_tests.py", line 169, in test_ray_intersect_aabb
    "Ray vs AABB intersection incorrect"
AssertionError: Ray vs AABB intersection incorrect

----------------------------------------------------------------------
Ran 49 tests in 0.150s

FAILED (failures=1)
```
