### PR TITLE
Added lookAt matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Authors
 
   * [Adam Griffiths](https://github.com/adamlwgriffiths/).
   * [Jakub Stasiak](https://github.com/jstasiak/).
+  * [Bogdan Teleaga](https://github.com/bogdanteleaga/).
 
 Contributions are welcome.
 

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -344,15 +344,15 @@ def create_orthogonal_projection_matrix(
     ), dtype=dtype)
 
 @all_parameters_as_numpy_arrays
-def create_lookAt(eye, target, up, dtype=None):
-    """Creates a lookAt matrix according to OpenGL standards.
+def create_look_at(eye, target, up, dtype=None):
+    """Creates a look at matrix according to OpenGL standards.
 
     :param numpy.array eye: Position of the camera in world coordinates.
     :param numpy.array target: The position in world coordinates that the
         camera is looking at.
     :param numpy.array up: The up vector of the camera.
     :rtype numpy.array
-    :return A lookAt matrix that can be used as a viewMatrix
+    :return A look at matrix that can be used as a viewMatrix
     """
 
     forward = vector.normalise(target - eye)

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -9,6 +9,7 @@ numpy.array.T method.
 from __future__ import absolute_import, division, print_function
 import numpy as np
 from . import matrix33
+from . import vector
 from .utils import all_parameters_as_numpy_arrays, parameters_as_numpy_arrays
 
 
@@ -340,6 +341,18 @@ def create_orthogonal_projection_matrix(
         (0., 0.,  C, 0.),
         (Tx, Ty, Tz, 1.),
     ), dtype=dtype)
+
+@all_parameters_as_numpy_arrays
+def create_lookAt(eye, target, up, dtype=None):
+    forward = vector.normalise(target - eye)
+    side = vector.normalise(np.cross(forward, up))
+    up = vector.normalise(np.cross(side, forward))
+
+    return np.array((
+        (side[0],            up[0],            -forward[0],           0.),
+        (side[1],            up[1],            -forward[1],           0.),
+        (side[2],            up[2],            -forward[2],           0.),
+        (-np.dot(side, eye), -np.dot(up, eye), np.dot(forward, eye) , 1.0)), dtype='f')
 
 def inverse(m):
     """Returns the inverse of the matrix.

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -360,10 +360,12 @@ def create_look_at(eye, target, up, dtype=None):
     up = vector.normalise(np.cross(side, forward))
 
     return np.array((
-        (side[0],            up[0],            -forward[0],           0.),
-        (side[1],            up[1],            -forward[1],           0.),
-        (side[2],            up[2],            -forward[2],           0.),
-        (-np.dot(side, eye), -np.dot(up, eye), np.dot(forward, eye) , 1.0)), dtype='f')
+            (side[0],            up[0],            -forward[0],           0.),
+            (side[1],            up[1],            -forward[1],           0.),
+            (side[2],            up[2],            -forward[2],           0.),
+            (-np.dot(side, eye), -np.dot(up, eye), np.dot(forward, eye) , 1.0)
+        ), dtype=dtype)
+        
 
 def inverse(m):
     """Returns the inverse of the matrix.

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -345,6 +345,16 @@ def create_orthogonal_projection_matrix(
 
 @all_parameters_as_numpy_arrays
 def create_lookAt(eye, target, up, dtype=None):
+    """Creates a lookAt matrix according to OpenGL standards.
+
+    :param numpy.array eye: Position of the camera in world coordinates.
+    :param numpy.array target: The position in world coordinates that the
+        camera is looking at.
+    :param numpy.array up: The up vector of the camera.
+    :rtype numpy.array
+    :return A lookAt matrix that can be used as a viewMatrix
+    """
+
     forward = vector.normalise(target - eye)
     side = vector.normalise(np.cross(forward, up))
     up = vector.normalise(np.cross(side, forward))

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -229,7 +229,8 @@ def create_perspective_projection_matrix(fovy, aspect, near, far, dtype=None):
     """
     ymax = near * np.tan(fovy * np.pi / 360.0)
     xmax = ymax * aspect
-    return create_perspective_projection_matrix_from_bounds(-xmax, xmax, -ymax, ymax, near, far)
+    return create_perspective_projection_matrix_from_bounds(-xmax, xmax, -ymax,
+                                                            ymax, near, far, dtype=dtype)
 
 def create_perspective_projection_matrix_from_bounds(
     left,

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -355,15 +355,15 @@ def create_look_at(eye, target, up, dtype=None):
     :return A look at matrix that can be used as a viewMatrix
     """
 
-    forward = vector.normalise(target - eye)
-    side = vector.normalise(np.cross(forward, up))
-    up = vector.normalise(np.cross(side, forward))
+    forward = vector.normalise(eye - target)
+    side = vector.normalise(np.cross(up, forward))
+    up = vector.normalise(np.cross(forward, side))
 
     return np.array((
-            (side[0],            up[0],            -forward[0],           0.),
-            (side[1],            up[1],            -forward[1],           0.),
-            (side[2],            up[2],            -forward[2],           0.),
-            (-np.dot(side, eye), -np.dot(up, eye), np.dot(forward, eye) , 1.0)
+            (side[0],            up[0],            forward[0],           0.),
+            (side[1],            up[1],            forward[1],           0.),
+            (side[2],            up[2],            forward[2],           0.),
+            (-np.dot(side, eye), -np.dot(up, eye), -np.dot(forward, eye) , 1.0)
         ), dtype=dtype)
         
 

--- a/pyrr/objects/matrix44.py
+++ b/pyrr/objects/matrix44.py
@@ -161,7 +161,7 @@ class Matrix44(BaseMatrix44):
     def lookAt(cls, eye, target, up, dtype=None):
         """Creates a Matrix44 for use as a lookAt matrix.
         """
-        return cls(matrix44.create_lookAt(eye, target, up, dtype=None))
+        return cls(matrix44.create_lookAt(eye, target, up, dtype))
 
     @classmethod
     def from_translation(cls, translation, dtype=None):

--- a/pyrr/objects/matrix44.py
+++ b/pyrr/objects/matrix44.py
@@ -158,6 +158,12 @@ class Matrix44(BaseMatrix44):
         return cls(matrix44.create_orthogonal_projection_matrix(left, right, top, bottom, near, far, dtype))
 
     @classmethod
+    def lookAt(cls, eye, target, up, dtype=None):
+        """Creates a Matrix44 for use as a lookAt matrix.
+        """
+        return cls(matrix44.create_lookAt(eye, target, up, dtype=None))
+
+    @classmethod
     def from_translation(cls, translation, dtype=None):
         """Creates a Matrix44 from the specified translation.
         """


### PR DESCRIPTION
So I was using your library in a project and I saw it lacks the lookAt matrix. After trying some other stuff I decided to add it myself. I've been using it for some days now with success, so I'd say it works properly. I also added the object wrapper since I mainly use them as objects. I had to modify my original implementation where I was using vec3's and mat4's with ^ and |, but I tested this out for a couple of minutes and it works.

Also, I've included a small driveby fix in the projection matrix where you weren't passing the dtype along.
