### PR TITLE
fix test suite name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url = 'https://github.com/adamlwgriffiths/Pyrr',
     install_requires = ['numpy', 'multipledispatch'],
     platforms = ['any'],
-    test_suite = 'tests',
+    test_suite = 'pyrr.tests',
     packages = ['pyrr','pyrr.objects', 'pyrr.tests'],
     classifiers = [
         'Natural Language :: English',


### PR DESCRIPTION
Making sure that `python setup.py test` finds the test suite.