### PR TITLE
rename getargspec to getfullargspec

### DIFF
--- a/pyrr/utils.py
+++ b/pyrr/utils.py
@@ -46,7 +46,10 @@ def parameters_as_numpy_arrays(*args_to_convert):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             # get the arguements of the function we're decorating
-            fn_args = inspect.getfullargspec(fn)
+            if 'getfullargspec' in dir(inspect):
+                fn_args = inspect.getfullargspec(fn)
+            else:
+                fn_args = inspect.getargspec(fn)
 
             # convert any values that are specified
             # if the argument isn't in our list, just pass it through

--- a/pyrr/utils.py
+++ b/pyrr/utils.py
@@ -46,7 +46,7 @@ def parameters_as_numpy_arrays(*args_to_convert):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             # get the arguements of the function we're decorating
-            fn_args = inspect.getargspec(fn)
+            fn_args = inspect.getfullargspec(fn)
 
             # convert any values that are specified
             # if the argument isn't in our list, just pass it through

--- a/pyrr/utils.py
+++ b/pyrr/utils.py
@@ -43,13 +43,16 @@ def parameters_as_numpy_arrays(*args_to_convert):
     def decorator(fn):
         # wraps allows us to pass the docstring back
         # or the decorator will hide the function from our doc generator
+
+        try:
+            getfullargspec = inspect.getfullargspec
+        except AttributeError:
+            getfullargspec = inspect.getargspec
+
         @wraps(fn)
         def wrapper(*args, **kwargs):
             # get the arguements of the function we're decorating
-            if 'getfullargspec' in dir(inspect):
-                fn_args = inspect.getfullargspec(fn)
-            else:
-                fn_args = inspect.getargspec(fn)
+            fn_args = getfullargspec(fn)
 
             # convert any values that are specified
             # if the argument isn't in our list, just pass it through


### PR DESCRIPTION
- fix 125 warnings:

```
pyrr/tests/objects/test_vector3.py::test_object_vector3::test_create
  ...\Pyrr\pyrr\utils.py:49: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
    fn_args = inspect.getargspec(fn)
```
