### PR TITLE
refactor function names

### DIFF
--- a/pyrr/geometric_tests.py
+++ b/pyrr/geometric_tests.py
@@ -137,10 +137,10 @@ def point_closest_point_on_ray(point, ray):
     n is the ray normal of unit length
     t is the distance along the ray to the point
     """
-    normalised_n = vector.normalise(ray[1])
+    normalized_n = vector.normalize(ray[1])
     relative_point = (point - ray[0])
-    t = vector.dot(relative_point, normalised_n)
-    return ray[0] + (normalised_n * t)
+    t = vector.dot(relative_point, normalized_n)
+    return ray[0] + (normalized_n * t)
 
 @all_parameters_as_numpy_arrays
 def point_closest_point_on_line(point, line):
@@ -155,7 +155,7 @@ def point_closest_point_on_line(point, line):
     """
     rl = va->b (relative line)
     rp = va->p (relative point)
-    u' = u / |u| (normalise)
+    u' = u / |u| (normalize)
     cp = a + (u' * (u'.v))
     where:
     a = line start
@@ -165,7 +165,7 @@ def point_closest_point_on_line(point, line):
     """
     rl = line[1] - line[0]
     rp = point - line[0]
-    rl = vector.normalise(rl)
+    rl = vector.normalize(rl)
     dot = vector.dot(rl, rp)
     return line[0] + (rl * dot)
 
@@ -214,7 +214,7 @@ def vector_parallel_vector(v1, v2):
     # if the result is 0, then they are parallel
     cross = vector3.cross(v1, v2)
     return 0 == np.count_nonzero(cross)
-    
+
 @all_parameters_as_numpy_arrays
 def ray_parallel_ray(ray1, ray2):
     """Checks if two rays are parallel.
@@ -385,7 +385,7 @@ def sphere_penetration_sphere(s1, s2):
     :rtype: float
     :return: The total overlap of the two spheres.
         This is essentially:
-        r1 + r2 - distance 
+        r1 + r2 - distance
         Where r1 and r2 are the radii of circle 1 and 2
         and distance is the length of the vector p2 - p1.
         Will return 0.0 if the circles do not overlap.

--- a/pyrr/matrix33.py
+++ b/pyrr/matrix33.py
@@ -86,7 +86,7 @@ def create_from_axis_rotation(axis, theta, dtype=None):
     """
     dtype = dtype or axis.dtype
 
-    axis = vector.normalise(axis)
+    axis = vector.normalize(axis)
     x,y,z = axis
 
     s = np.sin(theta);
@@ -114,9 +114,9 @@ def create_from_quaternion(quat, dtype=None):
     """
     dtype = dtype or quat.dtype
 
-    # the quaternion must be normalised
+    # the quaternion must be normalized
     if not np.isclose(np.linalg.norm(quat), 1.):
-        quat = quaternion.normalise(quat)
+        quat = quaternion.normalize(quat)
 
     # http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToMatrix/index.htm
     qx, qy, qz, qw = quat[0], quat[1], quat[2], quat[3]
@@ -364,7 +364,7 @@ def create_direction_scale(direction, scale):
     k is the scaling factor
     """
     if not np.isclose(np.linalg.norm(direction), 1.):
-        direction = vector.normalise(direction)
+        direction = vector.normalize(direction)
 
     x,y,z = direction
 

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -386,7 +386,7 @@ def create_look_at_matrix(eye, target, up, dtype=None):
 
 
 @all_parameters_as_numpy_arrays
-def create_look_at(eye, target, up, dtype=None):  # TODO: mark as duplicated
+def create_look_at(eye, target, up, dtype=None):  # TODO: mark as deprecated
     """Creates a look at matrix according to OpenGL standards.
 
     :param numpy.array eye: Position of the camera in world coordinates.

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -58,7 +58,7 @@ def create_from_eulers(eulers, dtype=None):
     # set to identity matrix
     # this will populate our extra rows for us
     mat = create_identity(dtype)
-    
+
     # we'll use Matrix33 for our conversion
     mat[0:3, 0:3] = matrix33.create_from_eulers(eulers, dtype)
     return mat
@@ -69,7 +69,7 @@ def create_from_axis_rotation(axis, theta, dtype=None):
 
     :param numpy.array axis: A (3,) vector.
     :param float theta: A rotation in radians.
-        
+
     :rtype: numpy.array
     :return: A matrix with shape (4,4).
     """
@@ -77,7 +77,7 @@ def create_from_axis_rotation(axis, theta, dtype=None):
     # set to identity matrix
     # this will populate our extra rows for us
     mat = create_identity(dtype)
-    
+
     # we'll use Matrix33 for our conversion
     mat[0:3, 0:3] = matrix33.create_from_axis_rotation(axis, theta, dtype)
     return mat
@@ -94,7 +94,7 @@ def create_from_quaternion(quat, dtype=None):
     # set to identity matrix
     # this will populate our extra rows for us
     mat = create_identity(dtype)
-    
+
     # we'll use Matrix33 for our conversion
     mat[0:3, 0:3] = matrix33.create_from_quaternion(quat, dtype)
     return mat
@@ -114,7 +114,7 @@ def create_from_inverse_of_quaternion(quat, dtype=None):
     # set to identity matrix
     # this will populate our extra rows for us
     mat = create_identity(dtype)
-    
+
     # we'll use Matrix33 for our conversion
     mat[0:3, 0:3] = matrix33.create_from_inverse_of_quaternion(quat, dtype)
     return mat
@@ -138,7 +138,7 @@ def create_from_scale(scale, dtype=None):
 
     :param numpy.array scale: The scale to apply as a vector (shape 3).
     :rtype: numpy.array
-    :return: A matrix with shape (4,4) with the scale 
+    :return: A matrix with shape (4,4) with the scale
         set to the specified vector.
     """
     # we need to expand 'scale' into it's components
@@ -155,7 +155,7 @@ def create_from_x_rotation(theta, dtype=None):
     :rtype: numpy.array
     :return: A matrix with the shape (4,4) with the specified rotation about
         the X-axis.
-    
+
     .. seealso:: http://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
     """
     mat = create_identity(dtype)
@@ -169,7 +169,7 @@ def create_from_y_rotation(theta, dtype=None):
     :rtype: numpy.array
     :return: A matrix with the shape (4,4) with the specified rotation about
         the Y-axis.
-    
+
     .. seealso:: http://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
     """
     mat = create_identity(dtype)
@@ -183,7 +183,7 @@ def create_from_z_rotation(theta, dtype=None):
     :rtype: numpy.array
     :return: A matrix with the shape (4,4) with the specified rotation about
         the Z-axis.
-    
+
     .. seealso:: http://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
     """
     mat = create_identity(dtype)
@@ -362,7 +362,7 @@ def create_orthogonal_projection_matrix(
     ), dtype=dtype)
 
 @all_parameters_as_numpy_arrays
-def create_look_at(eye, target, up, dtype=None):
+def create_look_at_matrix(eye, target, up, dtype=None):
     """Creates a look at matrix according to OpenGL standards.
 
     :param numpy.array eye: Position of the camera in world coordinates.
@@ -383,7 +383,21 @@ def create_look_at(eye, target, up, dtype=None):
             (side[2], up[2], -forward[2], 0.),
             (-np.dot(side, eye), -np.dot(up, eye), np.dot(forward, eye), 1.0)
         ), dtype=dtype)
-        
+
+
+@all_parameters_as_numpy_arrays
+def create_look_at(eye, target, up, dtype=None):  # TODO: mark as duplicated
+    """Creates a look at matrix according to OpenGL standards.
+
+    :param numpy.array eye: Position of the camera in world coordinates.
+    :param numpy.array target: The position in world coordinates that the
+        camera is looking at.
+    :param numpy.array up: The up vector of the camera.
+    :rtype: numpy.array
+    :return: A look at matrix that can be used as a viewMatrix
+    """
+
+    return create_look_at_matrix(eye, target, up, dtype)
 
 def inverse(m):
     """Returns the inverse of the matrix.

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -461,9 +461,9 @@ def create_look_at(eye, target, up, dtype=None):
     :return: A look at matrix that can be used as a viewMatrix
     """
 
-    forward = vector.normalise(target - eye)
-    side = vector.normalise(np.cross(forward, up))
-    up = vector.normalise(np.cross(side, forward))
+    forward = vector.normalize(target - eye)
+    side = vector.normalize(np.cross(forward, up))
+    up = vector.normalize(np.cross(side, forward))
 
     return np.array((
             (side[0], up[0], -forward[0], 0.),

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -233,7 +233,7 @@ def multiply(m1, m2):
     """
     return np.dot(m1, m2)
 
-def create_perspective_projection_matrix(fovy, aspect, near, far, dtype=None):
+def create_perspective_projection(fovy, aspect, near, far, dtype=None):
     """Creates perspective projection matrix.
 
     .. seealso:: http://www.opengl.org/sdk/docs/man2/xhtml/gluPerspective.xml
@@ -248,9 +248,24 @@ def create_perspective_projection_matrix(fovy, aspect, near, far, dtype=None):
     """
     ymax = near * np.tan(fovy * np.pi / 360.0)
     xmax = ymax * aspect
-    return create_perspective_projection_matrix_from_bounds(-xmax, xmax, -ymax, ymax, near, far, dtype=dtype)
+    return create_perspective_projection_from_bounds(-xmax, xmax, -ymax, ymax, near, far, dtype=dtype)
 
-def create_perspective_projection_matrix_from_bounds(
+def create_perspective_projection_matrix(fovy, aspect, near, far, dtype=None):    # TDOO: mark as deprecated
+    """Creates perspective projection matrix.
+
+    .. seealso:: http://www.opengl.org/sdk/docs/man2/xhtml/gluPerspective.xml
+    .. seealso:: http://www.geeks3d.com/20090729/howto-perspective-projection-matrix-in-opengl/
+
+    :param float fovy: field of view in y direction in degrees
+    :param float aspect: aspect ratio of the view (width / height)
+    :param float near: distance from the viewer to the near clipping plane (only positive)
+    :param float far: distance from the viewer to the far clipping plane (only positive)
+    :rtype: numpy.array
+    :return: A projection matrix representing the specified perpective.
+    """
+    return create_perspective_projection(fovy, aspect, near, far, dtype)
+
+def create_perspective_projection_from_bounds(
     left,
     right,
     bottom,
@@ -304,7 +319,44 @@ def create_perspective_projection_matrix_from_bounds(
         ( 0., 0.,  D, 0.),
     ), dtype=dtype)
 
-def create_orthogonal_projection_matrix(
+def create_perspective_projection_matrix_from_bounds(
+    left, right, bottom, top, near, far, dtype=None):    # TDOO: mark as deprecated
+    """Creates a perspective projection matrix using the specified near
+    plane dimensions.
+
+    :param float left: The left of the near plane relative to the plane's centre.
+    :param float right: The right of the near plane relative to the plane's centre.
+    :param float top: The top of the near plane relative to the plane's centre.
+    :param float bottom: The bottom of the near plane relative to the plane's centre.
+    :param float near: The distance of the near plane from the camera's origin.
+        It is recommended that the near plane is set to 1.0 or above to avoid rendering issues
+        at close range.
+    :param float far: The distance of the far plane from the camera's origin.
+    :rtype: numpy.array
+    :return: A projection matrix representing the specified perspective.
+
+    .. seealso:: http://www.gamedev.net/topic/264248-building-a-projection-matrix-without-api/
+    .. seealso:: http://www.glprogramming.com/red/chapter03.html
+    """
+
+    """
+    E 0 A 0
+    0 F B 0
+    0 0 C D
+    0 0-1 0
+
+    A = (right+left)/(right-left)
+    B = (top+bottom)/(top-bottom)
+    C = -(far+near)/(far-near)
+    D = -2*far*near/(far-near)
+    E = 2*near/(right-left)
+    F = 2*near/(top-bottom)
+    """
+    return create_perspective_projection_from_bounds(
+        left, right, bottom, top, near, far, dtype
+    )
+
+def create_orthogonal_projection(
     left,
     right,
     bottom,
@@ -361,8 +413,44 @@ def create_orthogonal_projection_matrix(
         (Tx, Ty, Tz, 1.),
     ), dtype=dtype)
 
+def create_orthogonal_projection_matrix(
+    left, right, bottom, top, near, far, dtype=None):    # TDOO: mark as deprecated
+    """Creates an orthogonal projection matrix.
+
+    :param float left: The left of the near plane relative to the plane's centre.
+    :param float right: The right of the near plane relative to the plane's centre.
+    :param float top: The top of the near plane relative to the plane's centre.
+    :param float bottom: The bottom of the near plane relative to the plane's centre.
+    :param float near: The distance of the near plane from the camera's origin.
+        It is recommended that the near plane is set to 1.0 or above to avoid rendering issues
+        at close range.
+    :param float far: The distance of the far plane from the camera's origin.
+    :rtype: numpy.array
+    :return: A projection matrix representing the specified orthogonal perspective.
+
+    .. seealso:: http://msdn.microsoft.com/en-us/library/dd373965(v=vs.85).aspx
+    """
+
+    """
+    A 0 0 Tx
+    0 B 0 Ty
+    0 0 C Tz
+    0 0 0 1
+
+    A = 2 / (right - left)
+    B = 2 / (top - bottom)
+    C = -2 / (far - near)
+
+    Tx = (right + left) / (right - left)
+    Ty = (top + bottom) / (top - bottom)
+    Tz = (far + near) / (far - near)
+    """
+    return create_orthogonal_projection(
+        left, right, bottom, top, near, far, dtype
+    )
+
 @all_parameters_as_numpy_arrays
-def create_look_at_matrix(eye, target, up, dtype=None):
+def create_look_at(eye, target, up, dtype=None):
     """Creates a look at matrix according to OpenGL standards.
 
     :param numpy.array eye: Position of the camera in world coordinates.
@@ -386,7 +474,7 @@ def create_look_at_matrix(eye, target, up, dtype=None):
 
 
 @all_parameters_as_numpy_arrays
-def create_look_at(eye, target, up, dtype=None):  # TODO: mark as deprecated
+def create_look_at_matrix(eye, target, up, dtype=None):    # TODO: mark as duplicated
     """Creates a look at matrix according to OpenGL standards.
 
     :param numpy.array eye: Position of the camera in world coordinates.
@@ -397,7 +485,7 @@ def create_look_at(eye, target, up, dtype=None):  # TODO: mark as deprecated
     :return: A look at matrix that can be used as a viewMatrix
     """
 
-    return create_look_at_matrix(eye, target, up, dtype)
+    return create_look_at(eye, target, up, dtype)
 
 def inverse(m):
     """Returns the inverse of the matrix.

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -473,20 +473,6 @@ def create_look_at(eye, target, up, dtype=None):
         ), dtype=dtype)
 
 
-@all_parameters_as_numpy_arrays
-def create_look_at_matrix(eye, target, up, dtype=None):    # TODO: mark as duplicated
-    """Creates a look at matrix according to OpenGL standards.
-
-    :param numpy.array eye: Position of the camera in world coordinates.
-    :param numpy.array target: The position in world coordinates that the
-        camera is looking at.
-    :param numpy.array up: The up vector of the camera.
-    :rtype: numpy.array
-    :return: A look at matrix that can be used as a viewMatrix
-    """
-
-    return create_look_at(eye, target, up, dtype)
-
 def inverse(m):
     """Returns the inverse of the matrix.
 

--- a/pyrr/objects/base.py
+++ b/pyrr/objects/base.py
@@ -105,6 +105,13 @@ class BaseVector(BaseObject):
     def normalized(self):
         return type(self)(self._module.normalize(self))
 
+    def normalise(self):    # TODO: mark as deprecated
+        self[:] = self.normalized
+
+    @property
+    def normalised(self):    # TODO: mark as deprecated
+        return type(self)(self._module.normalize(self))
+
     @property
     def squared_length(self):
         return self._module.squared_length(self)

--- a/pyrr/objects/base.py
+++ b/pyrr/objects/base.py
@@ -98,12 +98,12 @@ class BaseVector(BaseObject):
     def from_matrix44_translation(cls, matrix, dtype=None):
         return cls(cls._module.create_from_matrix44_translation(matrix, dtype))
 
-    def normalise(self):
-        self[:] = self.normalised
+    def normalize(self):
+        self[:] = self.normalized
 
     @property
-    def normalised(self):
-        return type(self)(self._module.normalise(self))
+    def normalized(self):
+        return type(self)(self._module.normalize(self))
 
     @property
     def squared_length(self):
@@ -126,8 +126,8 @@ class BaseVector(BaseObject):
     def interpolate(self, other, delta):
         return type(self)(vector.interpolate(self, type(self)(other), delta))
 
-    def normal(self, v2, v3, normalise_result=True):
-        return type(self)(vector3.generate_normals(self, type(self)(v2), type(self)(v3), normalise_result))
+    def normal(self, v2, v3, normalize_result=True):
+        return type(self)(vector3.generate_normals(self, type(self)(v2), type(self)(v3), normalize_result))
 
 class BaseQuaternion(BaseObject):
     pass

--- a/pyrr/objects/matrix44.py
+++ b/pyrr/objects/matrix44.py
@@ -143,19 +143,19 @@ class Matrix44(BaseMatrix44):
     def perspective_projection(cls, fovy, aspect, near, far, dtype=None):
         """Creates a Matrix44 for use as a perspective projection matrix.
         """
-        return cls(matrix44.create_perspective_projection_matrix(fovy, aspect, near, far, dtype))
+        return cls(matrix44.create_perspective_projection(fovy, aspect, near, far, dtype))
 
     @classmethod
     def perspective_projection_bounds(cls, left, right, top, bottom, near, far, dtype=None):
         """Creates a Matrix44 for use as a perspective projection matrix.
         """
-        return cls(matrix44.create_perspective_projection_matrix_from_bounds(left, right, top, bottom, near, far, dtype))
+        return cls(matrix44.create_perspective_projection_from_bounds(left, right, top, bottom, near, far, dtype))
 
     @classmethod
     def orthogonal_projection(cls, left, right, top, bottom, near, far, dtype=None):
         """Creates a Matrix44 for use as an orthogonal projection matrix.
         """
-        return cls(matrix44.create_orthogonal_projection_matrix(left, right, top, bottom, near, far, dtype))
+        return cls(matrix44.create_orthogonal_projection(left, right, top, bottom, near, far, dtype))
 
     @classmethod
     def look_at(cls, eye, target, up, dtype=None):

--- a/pyrr/objects/quaternion.py
+++ b/pyrr/objects/quaternion.py
@@ -201,16 +201,16 @@ class Quaternion(BaseQuaternion):
         """
         return quaternion.length(self)
 
-    def normalise(self):
-        """Normalises this Quaternion in-place.
+    def normalize(self):
+        """normalizes this Quaternion in-place.
         """
-        self[:] = quaternion.normalise(self)
+        self[:] = quaternion.normalize(self)
 
     @property
-    def normalised(self):
-        """Returns a normalised version of this Quaternion as a new Quaternion.
+    def normalized(self):
+        """Returns a normalized version of this Quaternion as a new Quaternion.
         """
-        return Quaternion(quaternion.normalise(self))
+        return Quaternion(quaternion.normalize(self))
 
     @property
     def angle(self):

--- a/pyrr/objects/quaternion.py
+++ b/pyrr/objects/quaternion.py
@@ -212,6 +212,17 @@ class Quaternion(BaseQuaternion):
         """
         return Quaternion(quaternion.normalize(self))
 
+    def normalise(self):    # TODO: mark as deprecated
+        """normalizes this Quaternion in-place.
+        """
+        self[:] = quaternion.normalize(self)
+
+    @property
+    def normalised(self):    # TODO: mark as deprecated
+        """Returns a normalized version of this Quaternion as a new Quaternion.
+        """
+        return Quaternion(quaternion.normalize(self))
+
     @property
     def angle(self):
         """Returns the angle around the axis of rotation of this Quaternion as a float.

--- a/pyrr/plane.py
+++ b/pyrr/plane.py
@@ -53,12 +53,12 @@ def create_from_points(vector1, vector2, vector3, dtype=None):
     # make the vectors relative to vector2
     relV1 = vector1 - vector2
     relV2 = vector3 - vector2
-    
+
     # cross our relative vectors
     normal = np.cross(relV1, relV2)
     if np.count_nonzero(normal) == 0:
         raise ValueError("Vectors are co-incident")
-    
+
     # create our plane
     return create_from_position(position=vector2, normal=normal, dtype=dtype)
 
@@ -68,7 +68,7 @@ def create_from_position(position, normal, dtype=None):
     and up being the rotation of the plane.
 
     :param numpy.array position: The position of the plane.
-    :param numpy.array normal: The normal of the plane. Will be normalised
+    :param numpy.array normal: The normal of the plane. Will be normalized
         during construction.
     :rtype: numpy.array
     :return: A plane that crosses the specified position with the specified
@@ -76,7 +76,7 @@ def create_from_position(position, normal, dtype=None):
     """
     dtype = dtype or position.dtype
     # -d = a * px  + b * py + c * pz
-    n = vector.normalise(normal)
+    n = vector.normalize(normal)
     d = -np.sum(n * position)
     return create(n, d, dtype)
 

--- a/pyrr/quaternion.py
+++ b/pyrr/quaternion.py
@@ -274,6 +274,17 @@ def normalize(quat):
     """
     return vector4.normalize(quat)
 
+def normalise(quat):    # TODO: mark as deprecated
+    """Ensure a quaternion is unit length (length ~= 1.0).
+
+    The quaternion is **not** changed in place.
+
+    :param numpy.array quat: The quaternion to normalize.
+    :rtype: numpy.array
+    :return: The normalized quaternion(s).
+    """
+    return vector4.normalize(quat)
+
 def rotation_angle(quat):
     """Calculates the rotation around the quaternion's axis.
 

--- a/pyrr/quaternion.py
+++ b/pyrr/quaternion.py
@@ -66,9 +66,9 @@ def create_from_z_rotation(theta, dtype=None):
 @parameters_as_numpy_arrays('axis')
 def create_from_axis_rotation(axis, theta, dtype=None):
     dtype = dtype or axis.dtype
-    # make sure the vector is normalised
+    # make sure the vector is normalized
     if not np.isclose(np.linalg.norm(axis), 1.):
-        axis = vector.normalise(axis)
+        axis = vector.normalize(axis)
 
     thetaOver2 = theta * 0.5
     sinThetaOver2 = np.sin(thetaOver2)
@@ -263,16 +263,16 @@ def length(quat):
     """
     return vector4.length(quat)
 
-def normalise(quat):
+def normalize(quat):
     """Ensure a quaternion is unit length (length ~= 1.0).
 
     The quaternion is **not** changed in place.
 
-    :param numpy.array quat: The quaternion to normalise.
+    :param numpy.array quat: The quaternion to normalize.
     :rtype: numpy.array
-    :return: The normalised quaternion(s).
+    :return: The normalized quaternion(s).
     """
-    return vector4.normalise(quat)
+    return vector4.normalize(quat)
 
 def rotation_angle(quat):
     """Calculates the rotation around the quaternion's axis.

--- a/pyrr/ray.py
+++ b/pyrr/ray.py
@@ -8,7 +8,7 @@ The first vector is the origin of the ray.
 The second vector is the direction of the ray
 relative to the origin.
 
-The following functions will normalise the ray
+The following functions will normalize the ray
 direction to unit length.
 Some functions may work correctly with directions
 that are not unit length, but this may vary from
@@ -34,7 +34,7 @@ def create(start, direction, dtype=None):
     return np.array(
         [
             start,
-            vector.normalise(direction)
+            vector.normalize(direction)
         ],
         dtype=dtype
     )
@@ -48,7 +48,7 @@ def create_from_line(line, dtype=None):
     return np.array(
         [
             line[0],
-            vector.normalise(line[1] - line[0])
+            vector.normalize(line[1] - line[0])
         ],
         dtype=dtype
     )

--- a/pyrr/tests/objects/test_quaternion.py
+++ b/pyrr/tests/objects/test_quaternion.py
@@ -126,18 +126,18 @@ class test_object_quaternion(unittest.TestCase):
         q = Quaternion.from_x_rotation(np.pi / 2.0)
         self.assertTrue(np.allclose(q.length, quaternion.length(q)))
 
-    def test_normalise(self):
+    def test_normalize(self):
         q = Quaternion([1., 2., 3., 4.])
         self.assertFalse(np.allclose(q.length, 1.))
 
-        q.normalise()
+        q.normalize()
         self.assertTrue(np.allclose(q.length, 1.))
 
-    def test_normalised(self):
+    def test_normalized(self):
         q1 = Quaternion([1., 2., 3., 4.])
         self.assertFalse(np.allclose(q1.length, 1.))
 
-        q2 = q1.normalised
+        q2 = q1.normalized
         self.assertFalse(np.allclose(q1.length, 1.))
         self.assertTrue(np.allclose(q2.length, 1.))
 

--- a/pyrr/tests/objects/test_vector3.py
+++ b/pyrr/tests/objects/test_vector3.py
@@ -72,11 +72,11 @@ class test_object_vector3(unittest.TestCase):
         v = Vector3([1.,2.,3.])
         self.assertTrue(np.array_equal(v.inverse, [-1.,-2.,-3.]))
 
-    def test_normalise(self):
+    def test_normalize(self):
         v = Vector3([1.,1.,1.])
-        np.testing.assert_almost_equal(v.normalised, [0.57735, 0.57735, 0.57735], decimal=5)
+        np.testing.assert_almost_equal(v.normalized, [0.57735, 0.57735, 0.57735], decimal=5)
 
-        v.normalise()
+        v.normalize()
         np.testing.assert_almost_equal(v, [0.57735, 0.57735, 0.57735], decimal=5)
 
     def test_operators_matrix33(self):

--- a/pyrr/tests/objects/test_vector4.py
+++ b/pyrr/tests/objects/test_vector4.py
@@ -25,7 +25,7 @@ class test_object_vector4(unittest.TestCase):
         from pyrr import Vector4
         from pyrr.objects import Vector4
         from pyrr.objects.vector4 import Vector4
-        
+
     def test_create(self):
         v = Vector4()
         self.assertTrue(np.array_equal(v, [0.,0.,0.,0.]))
@@ -55,11 +55,11 @@ class test_object_vector4(unittest.TestCase):
         v = Vector4([1.,2.,3.,4.])
         self.assertTrue(np.array_equal(v.inverse, [-1.,-2.,-3.,-4.]))
 
-    def test_normalise(self):
+    def test_normalize(self):
         v = Vector4([1.,1.,1.,1.])
-        np.testing.assert_almost_equal(v.normalised, [0.5, 0.5, 0.5, 0.5], decimal=5)
+        np.testing.assert_almost_equal(v.normalized, [0.5, 0.5, 0.5, 0.5], decimal=5)
 
-        v.normalise()
+        v.normalize()
         np.testing.assert_almost_equal(v, [0.5, 0.5, 0.5, 0.5], decimal=5)
 
     def test_operators_matrix33(self):

--- a/pyrr/tests/test_matrix33.py
+++ b/pyrr/tests/test_matrix33.py
@@ -103,7 +103,7 @@ class test_matrix33(unittest.TestCase):
         np.testing.assert_almost_equal(result, matrix33.create_from_quaternion([5.77350000e-01, 5.77350000e-01, 5.77350000e-01, 6.12323400e-17]), decimal=3)
         self.assertTrue(result.dtype == np.float)
 
-    def test_create_from_axis_rotation_non_normalised(self):
+    def test_create_from_axis_rotation_non_normalized(self):
         result = matrix33.create_from_axis_rotation([1.,1.,1.], np.pi)
         np.testing.assert_almost_equal(result, matrix33.create_from_quaternion([5.77350000e-01, 5.77350000e-01, 5.77350000e-01, 6.12323400e-17]), decimal=3)
         self.assertTrue(result.dtype == np.float)

--- a/pyrr/tests/test_matrix44.py
+++ b/pyrr/tests/test_matrix44.py
@@ -291,7 +291,7 @@ class test_matrix44(unittest.TestCase):
         apply_test(m, np.array((-1.1,-1.1,-10.,1.)), False)
 
     def test_create_look_at_determinant(self):
-        m = matrix44.create_look_at_matrix(
+        m = matrix44.create_look_at(
             np.array((300.0, 200.0, 100.0)),
             np.array((0.0, 0.0, 0.0)),
             np.array((0.0, 0.0, 1.0)),
@@ -300,7 +300,7 @@ class test_matrix44(unittest.TestCase):
         self.assertAlmostEqual(np.linalg.det(m), 1.0)
 
     def test_create_look_at(self):
-        m = matrix44.create_look_at_matrix(
+        m = matrix44.create_look_at(
             np.array((300.0, 200.0, 100.0)),
             np.array((0.0, 0.0, 10.0)),
             np.array((0.0, 0.0, 1.0)),
@@ -325,7 +325,7 @@ class test_matrix44(unittest.TestCase):
             self.assertAlmostEqual(w, 1.0)
 
     def test_create_look_at_2(self):
-        m = matrix44.create_look_at_matrix(
+        m = matrix44.create_look_at(
             np.array((10.0, 0.0, 0.0)),
             np.array((-10.0, 0.0, 0.0)),
             np.array((0.0, 1.0, 0.0)),
@@ -347,7 +347,7 @@ class test_matrix44(unittest.TestCase):
         self.assertAlmostEqual(z, -10.0)
 
     def test_create_look_at_3(self):
-        m = matrix44.create_look_at_matrix(
+        m = matrix44.create_look_at(
             np.array((10.0, 0.0, 0.0)),
             np.array((-10.0, 0.0, 0.0)),
             np.array((0.0, 1.0, 0.0)),
@@ -369,7 +369,7 @@ class test_matrix44(unittest.TestCase):
         self.assertAlmostEqual(z, 0.0)
 
     def test_create_look_at_4(self):
-        m = matrix44.create_look_at_matrix(
+        m = matrix44.create_look_at(
             np.array((0.0, 0.0, 0.0)),
             np.array((0.0, 0.0, -1.0)),
             np.array((0.0, 1.0, 0.0)),

--- a/pyrr/tests/test_matrix44.py
+++ b/pyrr/tests/test_matrix44.py
@@ -291,7 +291,7 @@ class test_matrix44(unittest.TestCase):
         apply_test(m, np.array((-1.1,-1.1,-10.,1.)), False)
 
     def test_create_look_at_determinant(self):
-        m = matrix44.create_look_at(
+        m = matrix44.create_look_at_matrix(
             np.array((300.0, 200.0, 100.0)),
             np.array((0.0, 0.0, 0.0)),
             np.array((0.0, 0.0, 1.0)),
@@ -300,7 +300,7 @@ class test_matrix44(unittest.TestCase):
         self.assertAlmostEqual(np.linalg.det(m), 1.0)
 
     def test_create_look_at(self):
-        m = matrix44.create_look_at(
+        m = matrix44.create_look_at_matrix(
             np.array((300.0, 200.0, 100.0)),
             np.array((0.0, 0.0, 10.0)),
             np.array((0.0, 0.0, 1.0)),
@@ -325,7 +325,7 @@ class test_matrix44(unittest.TestCase):
             self.assertAlmostEqual(w, 1.0)
 
     def test_create_look_at_2(self):
-        m = matrix44.create_look_at(
+        m = matrix44.create_look_at_matrix(
             np.array((10.0, 0.0, 0.0)),
             np.array((-10.0, 0.0, 0.0)),
             np.array((0.0, 1.0, 0.0)),
@@ -347,7 +347,7 @@ class test_matrix44(unittest.TestCase):
         self.assertAlmostEqual(z, -10.0)
 
     def test_create_look_at_3(self):
-        m = matrix44.create_look_at(
+        m = matrix44.create_look_at_matrix(
             np.array((10.0, 0.0, 0.0)),
             np.array((-10.0, 0.0, 0.0)),
             np.array((0.0, 1.0, 0.0)),
@@ -369,7 +369,7 @@ class test_matrix44(unittest.TestCase):
         self.assertAlmostEqual(z, 0.0)
 
     def test_create_look_at_4(self):
-        m = matrix44.create_look_at(
+        m = matrix44.create_look_at_matrix(
             np.array((0.0, 0.0, 0.0)),
             np.array((0.0, 0.0, -1.0)),
             np.array((0.0, 1.0, 0.0)),
@@ -456,6 +456,6 @@ class test_matrix44(unittest.TestCase):
         result = matrix44.inverse(m)
         self.assertTrue(np.allclose(result, matrix44.create_from_y_rotation(-np.pi)))
 
-    
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyrr/tests/test_matrix44.py
+++ b/pyrr/tests/test_matrix44.py
@@ -71,7 +71,7 @@ class test_matrix44(unittest.TestCase):
         np.testing.assert_almost_equal(result, matrix44.create_from_quaternion([5.77350000e-01, 5.77350000e-01, 5.77350000e-01, 6.12323400e-17]), decimal=3)
         self.assertTrue(result.dtype == np.float)
 
-    def test_create_from_axis_rotation_non_normalised(self):
+    def test_create_from_axis_rotation_non_normalized(self):
         result = matrix44.create_from_axis_rotation([1.,1.,1.], np.pi)
         np.testing.assert_almost_equal(result, matrix44.create_from_quaternion([5.77350000e-01, 5.77350000e-01, 5.77350000e-01, 6.12323400e-17]), decimal=3)
         self.assertTrue(result.dtype == np.float)

--- a/pyrr/tests/test_quaternion.py
+++ b/pyrr/tests/test_quaternion.py
@@ -67,7 +67,7 @@ class test_quaternion(unittest.TestCase):
         np.testing.assert_almost_equal(result, [5.77350000e-01, 5.77350000e-01, 5.77350000e-01, 6.12323400e-17], decimal=3)
         self.assertTrue(result.dtype == np.float)
 
-    def test_create_from_axis_rotation_non_normalised(self):
+    def test_create_from_axis_rotation_non_normalized(self):
         result = quaternion.create_from_axis_rotation([1., 1., 1.], np.pi)
         np.testing.assert_almost_equal(result, [5.77350000e-01, 5.77350000e-01, 5.77350000e-01, 6.12323400e-17], decimal=3)
         self.assertTrue(result.dtype == np.float)
@@ -164,19 +164,19 @@ class test_quaternion(unittest.TestCase):
         ])
         np.testing.assert_almost_equal(result, [1., 2.], decimal=5)
 
-    def test_normalise_identity(self):
-        # normalise an identity quaternion
-        result = quaternion.normalise([0., 0., 0., 1.])
+    def test_normalize_identity(self):
+        # normalize an identity quaternion
+        result = quaternion.normalize([0., 0., 0., 1.])
         np.testing.assert_almost_equal(result, [0., 0., 0., 1.], decimal=5)
 
-    def test_normalise_non_identity(self):
-        # normalise an identity quaternion
-        result = quaternion.normalise([1., 2., 3., 4.])
+    def test_normalize_non_identity(self):
+        # normalize an identity quaternion
+        result = quaternion.normalize([1., 2., 3., 4.])
         np.testing.assert_almost_equal(result, [1. / np.sqrt(30.), np.sqrt(2. / 15.), np.sqrt(3. / 10.), 2. * np.sqrt(2. / 15.)], decimal=5)
 
-    def test_normalise_batch(self):
-        # normalise an identity quaternion
-        result = quaternion.normalise([
+    def test_normalize_batch(self):
+        # normalize an identity quaternion
+        result = quaternion.normalize([
             [0., 0., 0., 1.],
             [1., 2., 3., 4.],
         ])

--- a/pyrr/tests/test_vector.py
+++ b/pyrr/tests/test_vector.py
@@ -12,12 +12,12 @@ class test_vector(unittest.TestCase):
         pyrr.vector
         from pyrr import vector
 
-    def test_normalise_single_vector(self):
-        result = vector3.normalise([1.,1.,1.])
+    def test_normalize_single_vector(self):
+        result = vector3.normalize([1.,1.,1.])
         np.testing.assert_almost_equal(result, [0.57735, 0.57735, 0.57735], decimal=5)
 
-    def test_normalise_batch(self):
-        result = vector3.normalise([
+    def test_normalize_batch(self):
+        result = vector3.normalize([
             [1.,1.,1.],
             [-1.,-1.,-1.],
             [0.,2.,7.],

--- a/pyrr/tests/test_vector3.py
+++ b/pyrr/tests/test_vector3.py
@@ -85,12 +85,12 @@ class test_vector3(unittest.TestCase):
         np.testing.assert_almost_equal(result, [13.,14.,15.], decimal=5)
         self.assertTrue(result.dtype == np.float32)
 
-    def test_normalise_single_vector(self):
-        result = vector3.normalise([1.,1.,1.])
+    def test_normalize_single_vector(self):
+        result = vector3.normalize([1.,1.,1.])
         np.testing.assert_almost_equal(result, [0.57735, 0.57735, 0.57735], decimal=5)
 
-    def test_normalise_batch(self):
-        result = vector3.normalise([
+    def test_normalize_batch(self):
+        result = vector3.normalize([
             [1.,1.,1.],
             [-1.,-1.,-1.],
             [0.,2.,7.],

--- a/pyrr/tests/test_vector4.py
+++ b/pyrr/tests/test_vector4.py
@@ -88,12 +88,12 @@ class test_vector4(unittest.TestCase):
         np.testing.assert_almost_equal(result, [13.,14.,15.,16.], decimal=5)
         self.assertTrue(result.dtype == np.float32)
 
-    def test_normalise_single_vector(self):
-        result = vector4.normalise([1.,1.,1.,1.])
+    def test_normalize_single_vector(self):
+        result = vector4.normalize([1.,1.,1.,1.])
         np.testing.assert_almost_equal(result, [0.5, 0.5, 0.5, 0.5], decimal=5)
 
-    def test_normalise_batch(self):
-        result = vector4.normalise([
+    def test_normalize_batch(self):
+        result = vector4.normalize([
             [1.,1.,1.,1.],
             [-1.,-1.,-1.,1.],
             [0.,2.,7.,1.],

--- a/pyrr/vector.py
+++ b/pyrr/vector.py
@@ -38,6 +38,37 @@ def normalize(vec):
 
 
 @all_parameters_as_numpy_arrays
+def normalise(vec):    # TODO: mark as deprecated
+    """normalizes an Nd list of vectors or a single vector
+    to unit length.
+
+    The vector is **not** changed in place.
+
+    For zero-length vectors, the result will be np.nan.
+
+    :param numpy.array vec: an Nd array with the final dimension
+        being vectors
+        ::
+
+            numpy.array([ x, y, z ])
+
+        Or an NxM array::
+
+            numpy.array([
+                [x1, y1, z1],
+                [x2, y2, z2]
+            ]).
+
+    :rtype: A numpy.array the normalized value
+    """
+    # calculate the length
+    # this is a duplicate of length(vec) because we
+    # always want an array, even a 0-d array.
+    return (vec.T  / np.sqrt(np.sum(vec**2,axis=-1))).T
+
+
+
+@all_parameters_as_numpy_arrays
 def squared_length(vec):
     """Calculates the squared length of a vector.
 

--- a/pyrr/vector.py
+++ b/pyrr/vector.py
@@ -7,8 +7,8 @@ from .utils import all_parameters_as_numpy_arrays, parameters_as_numpy_arrays
 
 
 @all_parameters_as_numpy_arrays
-def normalise(vec):
-    """Normalises an Nd list of vectors or a single vector
+def normalize(vec):
+    """normalizes an Nd list of vectors or a single vector
     to unit length.
 
     The vector is **not** changed in place.
@@ -28,7 +28,7 @@ def normalise(vec):
                 [x2, y2, z2]
             ]).
 
-    :rtype: A numpy.array the normalised value
+    :rtype: A numpy.array the normalized value
     """
     # calculate the length
     # this is a duplicate of length(vec) because we
@@ -36,7 +36,7 @@ def normalise(vec):
     return (vec.T  / np.sqrt(np.sum(vec**2,axis=-1))).T
 
 
-    
+
 @all_parameters_as_numpy_arrays
 def squared_length(vec):
     """Calculates the squared length of a vector.
@@ -66,7 +66,7 @@ def length(vec):
             numpy.array([ x, y, z ])
 
         Nd array::
-        
+
             numpy.array([
                 [x1, y1, z1],
                 [x2, y2, z2]
@@ -105,7 +105,7 @@ def set_length(vec, len):
 
     return (vec.T  / np.sqrt(np.sum(vec**2,axis=-1)) * len).T
 
-    
+
 @all_parameters_as_numpy_arrays
 def dot(v1, v2):
     """Calculates the dot product of two vectors.

--- a/pyrr/vector3.py
+++ b/pyrr/vector3.py
@@ -44,11 +44,11 @@ def cross(v1, v2):
     """
     return np.cross(v1, v2)
 
-def generate_normals(v1, v2, v3, normalise_result=True):
+def generate_normals(v1, v2, v3, normalize_result=True):
     """Generates a normal vector for 3 vertices.
 
-    The result is a normalised vector.
-    
+    The result is a normalized vector.
+
     It is assumed the ordering is counter-clockwise starting
     at v1, v2 then v3::
 
@@ -80,16 +80,16 @@ def generate_normals(v1, v2, v3, normalise_result=True):
         being size 3. (a vector)
     :param numpy.array v3: an Nd array with the final dimension
         being size 3. (a vector)
-    :param boolean normalise_result: Specifies if the result should
-        be normalised before being returned.
+    :param boolean normalize_result: Specifies if the result should
+        be normalized before being returned.
     """
     # make vectors relative to v2
     # we assume opengl counter-clockwise ordering
     a = v1 - v2
     b = v3 - v2
     n = cross(b, a)
-    if normalise_result:
-        normalise(n)
+    if normalize_result:
+        normalize(n)
     return n
 
 


### PR DESCRIPTION
### Changed

- Renamed `create_look_at` to `create_look_at_matrix`
- Kept `create_look_at` and marked as `TODO: mark as deprecated`

### Reason

There are similar functions:

- create_perspective_projection_matrix
- create_perspective_projection_matrix_from_bounds
- create_orthogonal_projection_matrix
- **create_look_at_matrix**