### PR TITLE
generate_vertex_normals + generate_normals bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,11 @@ Authors
 -------
 
   * [Adam Griffiths](https://github.com/adamlwgriffiths/).
-  * [Chris Bates](https://github.com/chrsbats)
-  * [Jakub Stasiak](https://github.com/jstasiak/).
+  * [Chris Bates](https://github.com/chrsbats/).
+  * [Jakub Stasiak](https://github.com/jstasiak/).
   * [Bogdan Teleaga](https://github.com/bogdanteleaga/).
-  * [Szabolcs Dombi](https://github.com/cprogrammer1994)
+  * [Szabolcs Dombi](https://github.com/cprogrammer1994/).
+  * [Korijn van Golen](https://github.com/Korijn/).
 
 Contributions are welcome.
 

--- a/docs/source/info_contributing.rst
+++ b/docs/source/info_contributing.rst
@@ -25,5 +25,6 @@ Developers and contributors include:
 
     * `Adam Griffiths <https://github.com/adamlwgriffiths/>`_
     * `Jakub Stasiak <https://github.com/jstasiak/>`_
+    * `Korijn van Golen <https://github.com/Korijn/>`_
 
 Is your name left out? Post an issue in `Pyrr's bug tracker <https://github.com/adamlwgriffiths/Pyrr/issues/>`_ =)

--- a/pyrr/tests/test_vector3.py
+++ b/pyrr/tests/test_vector3.py
@@ -102,6 +102,85 @@ class test_vector3(unittest.TestCase):
         ]
         np.testing.assert_almost_equal(result, expected, decimal=5)
 
+    def test_generate_normals(self):
+        vertices = np.array([
+            [2.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [2.0, 2.0, 0.0]
+        ])
+        index = np.array([
+            [0, 2, 1],
+            [0, 3, 2],
+        ])
+        v1, v2, v3 = np.rollaxis(vertices[index], axis=1)
+        result = vector3.generate_normals(v1, v2, v3)
+        expected = np.array([
+            [0., 0., 1.],
+            [0., 0., 1.]
+        ])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_generate_normals_unnormalized(self):
+        vertices = np.array([
+            [2.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [2.0, 2.0, 0.0]
+        ])
+        index = np.array([
+            [0, 2, 1],
+            [0, 3, 2],
+        ])
+        v1, v2, v3 = np.rollaxis(vertices[index], axis=1)
+        result = vector3.generate_normals(v1, v2, v3, normalize_result=False)
+        expected = np.array([
+            [0., 0., 4.],
+            [0., 0., 4.]
+        ])
+        np.testing.assert_array_equal(result, expected)
+
+    def test_generate_vertex_normals(self):
+        vertices = np.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0]
+        ])
+        index = np.array([
+            [0, 2, 1],
+            [0, 3, 2],
+        ])
+        result = vector3.generate_vertex_normals(vertices, index)
+        expected = np.array([
+            [0., 0., 1.],
+            [0., 0., 1.],
+            [0., 0., 1.],
+            [0., 0., 1.]
+        ])
+        np.testing.assert_array_equal(result, expected)
+    
+    def test_generate_vertex_normals_unnormalized(self):
+        vertices = np.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [1.0, 1.0, 0.0]
+        ])
+        index = np.array([
+            [0, 2, 1],
+            [0, 3, 2],
+        ])
+        result = vector3.generate_vertex_normals(
+            vertices, index, normalize_result=False)
+        expected = np.array([
+            [0., 0., 2.],
+            [0., 0., 1.],
+            [0., 0., 2.],
+            [0., 0., 1.]
+        ])
+        np.testing.assert_array_equal(result, expected)
+
     def test_squared_length_single_vector(self):
         result = vector3.squared_length([1.,1.,1.])
         np.testing.assert_almost_equal(result, 3., decimal=5)

--- a/pyrr/vector3.py
+++ b/pyrr/vector3.py
@@ -117,11 +117,11 @@ def generate_vertex_normals(vertices, index, normalize_result=True):
     :param boolean normalize_result: Specifies if the result should
         be normalized before being returned.
     """
-    v1, v2, v3 = np.rollaxis(vertices[index], axis=1)
+    v1, v2, v3 = np.rollaxis(vertices[index], axis=-2)
     face_normals = generate_normals(v1, v2, v3, normalize_result=False)
     vertex_normals = np.zeros_like(vertices)
     for i in range(3):
-        np.add.at(vertex_normals, index[:, i], face_normals)
+        np.add.at(vertex_normals, index[..., i], face_normals)
     if normalize_result:
         vertex_normals = normalize(vertex_normals)
     return vertex_normals

--- a/pyrr/vector3.py
+++ b/pyrr/vector3.py
@@ -89,8 +89,43 @@ def generate_normals(v1, v2, v3, normalize_result=True):
     b = v3 - v2
     n = cross(b, a)
     if normalize_result:
-        normalize(n)
+        n = normalize(n)
     return n
+
+def generate_vertex_normals(vertices, index, normalize_result=True):
+    """Generates a normal vector for each vertex.
+
+    The result is a normalized vector.
+
+    The index array should list the faces by indexing into the
+    vertices array. It is assumed the ordering in index is
+    counter-clockwise.
+
+    The vertices and index arrays are Nd arrays and must be at
+    least 2d. As long as the final axis is of size 3.
+
+    An example::
+        >>> vertices = numpy.array( [ [ 1.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0 ], [ 0.0, 1.0, 0.0 ] ] )
+        >>> index = numpy.array( [ [ 0, 2, 1 ] ] )
+        >>> vector.generate_vertex_normals( vertices, index )
+        array([[ 0.,  0., 1.]])
+
+    :param numpy.array vertices: an Nd array with the final dimension
+        being size 3. (a vector)
+    :param numpy.array index: an Nd array with the final dimension
+        being size 3. (a vector)
+    :param boolean normalize_result: Specifies if the result should
+        be normalized before being returned.
+    """
+
+    v1, v2, v3 = np.rollaxis(vertices[index], axis=1)
+    face_normals = generate_normals(v1, v2, v3, normalize_result=False)
+    vertex_normals = np.zeros_like(vertices)
+    for i in range(3):
+        np.add.at(vertex_normals, index[:, i], face_normals)
+    if normalize_result:
+        vertex_normals = normalize(vertex_normals)
+    return vertex_normals
 
 
 class index:

--- a/pyrr/vector3.py
+++ b/pyrr/vector3.py
@@ -108,7 +108,7 @@ def generate_vertex_normals(vertices, index, normalize_result=True):
         >>> vertices = numpy.array( [ [ 1.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0 ], [ 0.0, 1.0, 0.0 ] ] )
         >>> index = numpy.array( [ [ 0, 2, 1 ] ] )
         >>> vector.generate_vertex_normals( vertices, index )
-        array([[ 0.,  0., 1.]])
+        array([[ 0.,  0., 1.], [ 0.,  0., 1.], [ 0.,  0., 1.]])
 
     :param numpy.array vertices: an Nd array with the final dimension
         being size 3. (a vector)
@@ -117,7 +117,6 @@ def generate_vertex_normals(vertices, index, normalize_result=True):
     :param boolean normalize_result: Specifies if the result should
         be normalized before being returned.
     """
-
     v1, v2, v3 = np.rollaxis(vertices[index], axis=1)
     face_normals = generate_normals(v1, v2, v3, normalize_result=False)
     vertex_normals = np.zeros_like(vertices)

--- a/pyrr/vector3.py
+++ b/pyrr/vector3.py
@@ -101,8 +101,8 @@ def generate_vertex_normals(vertices, index, normalize_result=True):
     vertices array. It is assumed the ordering in index is
     counter-clockwise.
 
-    The vertices and index arrays are Nd arrays and must be at
-    least 2d. As long as the final axis is of size 3.
+    The vertices and index arrays are Nd arrays and must be 2d,
+    where the final axis is of size 3.
 
     An example::
         >>> vertices = numpy.array( [ [ 1.0, 0.0, 0.0 ], [ 0.0, 0.0, 0.0 ], [ 0.0, 1.0, 0.0 ] ] )
@@ -110,7 +110,7 @@ def generate_vertex_normals(vertices, index, normalize_result=True):
         >>> vector.generate_vertex_normals( vertices, index )
         array([[ 0.,  0., 1.], [ 0.,  0., 1.], [ 0.,  0., 1.]])
 
-    :param numpy.array vertices: an Nd array with the final dimension
+    :param numpy.array vertices: an 2d array with the final dimension
         being size 3. (a vector)
     :param numpy.array index: an Nd array with the final dimension
         being size 3. (a vector)


### PR DESCRIPTION
Fix #60

* added `pyrr.vector3.generate_vertex_normals`
* fixed a bug in `pyrr.vector3.generate_normals` where `normalize_result` was being ignored
* added unit tests for both functions
* I'm not sure I got the docstring format right. :)