### PR TITLE
Bugfix in ray_intersects_aabb

### DIFF
--- a/pyrr/geometric_tests.py
+++ b/pyrr/geometric_tests.py
@@ -285,7 +285,6 @@ def ray_intersect_aabb(ray, aabb):
     t5 = (aabb[0,2] - ray[0,2]) * dir_fraction[ 2 ]
     t6 = (aabb[1,2] - ray[0,2]) * dir_fraction[ 2 ]
 
-
     tmin = max(min(t1, t2), min(t3, t4), min(t5, t6))
     tmax = min(max(t1, t2), max(t3, t4), max(t5, t6))
 
@@ -301,7 +300,7 @@ def ray_intersect_aabb(ray, aabb):
     # t is the distance from the ray point
     # to intersection
 
-    t = abs(tmin)
+    t = min(x for x in [tmin, tmax] if x >= 0)
     point = ray[0] + (ray[1] * t)
     return point
 

--- a/pyrr/geometric_tests.py
+++ b/pyrr/geometric_tests.py
@@ -285,6 +285,7 @@ def ray_intersect_aabb(ray, aabb):
     t5 = (aabb[0,2] - ray[0,2]) * dir_fraction[ 2 ]
     t6 = (aabb[1,2] - ray[0,2]) * dir_fraction[ 2 ]
 
+
     tmin = max(min(t1, t2), min(t3, t4), min(t5, t6))
     tmax = min(max(t1, t2), max(t3, t4), max(t5, t6))
 

--- a/pyrr/tests/test_geometric_tests.py
+++ b/pyrr/tests/test_geometric_tests.py
@@ -6,6 +6,7 @@ import numpy as np
 from pyrr import geometric_tests as gt
 from pyrr import line, plane, ray, sphere
 
+
 class test_geometric_tests(unittest.TestCase):
     def test_import(self):
         import pyrr
@@ -188,6 +189,12 @@ class test_geometric_tests(unittest.TestCase):
         result = gt.ray_intersect_aabb(r, a)
         self.assertTrue(np.array_equal(result, [1.0, 1.0, 1.0]))
 
+    def test_ray_intersect_aabb_valid_3(self):
+        a = np.array([[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]])
+        r = np.array([[.5, .5, .5], [0, 0, 1.0]])
+        result = gt.ray_intersect_aabb(r, a)
+        self.assertTrue(np.array_equal(result, [.5, .5, 1.0]))
+
     def test_ray_intersect_aabb_invalid_1(self):
         a = np.array([[-1.0,-1.0,-1.0], [ 1.0, 1.0, 1.0]])
         r = np.array([[2.0, 2.0, 2.0], [ 1.0, 1.0, 1.0]])
@@ -251,6 +258,7 @@ class test_geometric_tests(unittest.TestCase):
         s1 = sphere.create()
         s2 = sphere.create([3.,0.,0.], 1.0)
         self.assertEqual(gt.sphere_penetration_sphere(s1, s2), 0.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Maybe I am missing something, but it looks like this code does not handle the case with negative values in aabb correctly:

bbox =  [[-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]]
ray = [[.5, .5, .5], [0, 0, 1.0]]
pyrr.geometric_tests.ray_intersect_aabb(ray, bbox)

array([0.5, 0.5, 2. ])

Proposed change fixes it.