### PR TITLE
Equality check quaternion. Q == -Q rotation.

### DIFF
--- a/pyrr/objects/quaternion.py
+++ b/pyrr/objects/quaternion.py
@@ -189,11 +189,15 @@ class Quaternion(BaseQuaternion):
 
     @dispatch((BaseQuaternion, np.ndarray, list))
     def __ne__(self, other):
-        return bool(np.any(super(Quaternion, self).__ne__(other)))
+        # For quaternions q and -q represent the same rotation
+        return bool(np.any(super(Quaternion, self).__ne__(other)))\
+               or bool(np.all(super(Quaternion, self).__eq__(-other)))
 
     @dispatch((BaseQuaternion, np.ndarray, list))
     def __eq__(self, other):
-        return bool(np.all(super(Quaternion, self).__eq__(other)))
+        # For quaternions q and -q represent the same rotation
+        return bool(np.all(super(Quaternion, self).__eq__(other))) \
+               or bool(np.all(super(Quaternion, self).__eq__(-other)))
 
     ########################
     # Matrices

--- a/tests/objects/test_quaternion.py
+++ b/tests/objects/test_quaternion.py
@@ -347,6 +347,20 @@ class test_object_quaternion(unittest.TestCase):
         self.assertEqual(q.x, 2)
         self.assertEqual(q[0], 2)
 
+    def test_equality(self):
+        q1 = Quaternion([0, 0, 0, 1])
+        q2 = Quaternion([0, 0, 0, 1])
+        q3 = Quaternion([0, 0, 1, -1])
+        self.assertEqual(q1, q2)
+        self.assertNotEqual(q1, q3)
+        self.assertNotEqual(q2, q3)
+
+    def test_equality_negative(self):
+        q1 = Quaternion([0, 0, 0, 1])
+        q2 = Quaternion([0, 0, 0, -1])
+        q3 = Quaternion([0, 0, 1, -1])
+        self.assertEqual(q1, q2)
+        self.assertNotEqual(q1, q3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Comparing two quaternions for rotation would mean that an equality test should be true for q and -q. Both quaternions represent exactly the same rotation.