### PR TITLE
Bug/fix matrix apply to vector

### DIFF
--- a/pyrr/matrix33.py
+++ b/pyrr/matrix33.py
@@ -302,7 +302,7 @@ def apply_to_vector(mat, vec):
     :return: The vectors rotated by the specified matrix.
     """
     if vec.size == 3:
-        return np.dot(vec, mat)
+        return np.dot(mat, vec)
     else:
         raise ValueError("Vector size unsupported")
 

--- a/pyrr/matrix44.py
+++ b/pyrr/matrix44.py
@@ -209,14 +209,14 @@ def apply_to_vector(mat, vec):
     if vec.size == 3:
         # convert to a vec4
         vec4 = np.array([vec[0], vec[1], vec[2], 1.], dtype=vec.dtype)
-        vec4 = np.dot(vec4, mat)
+        vec4 = np.dot(mat, vec4)
         if np.allclose(vec4[3], 0.):
             vec4[:] = [np.inf, np.inf, np.inf, np.inf]
         else:
             vec4 /= vec4[3]
         return vec4[:3]
     elif vec.size == 4:
-        return np.dot(vec, mat)
+        return np.dot(mat, vec)
     else:
         raise ValueError("Vector size unsupported")
 

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -20,11 +20,11 @@ class test_matrix_quaternion(unittest.TestCase):
         q = quaternion.create_from_x_rotation(np.pi / 2.)
         qm = matrix44.create_from_quaternion(q)
 
-        self.assertTrue(np.allclose(np.dot([1., 0., 0., 1.], m), [1., 0., 0., 1.]))
-        self.assertTrue(np.allclose(np.dot([1., 0., 0., 1.], qm), [1., 0., 0., 1.]))
+        self.assertTrue(np.allclose(np.dot(m, [0., 1., 0., 1.]), [0., 0., 1., 1.]))
+        self.assertTrue(np.allclose(np.dot(qm, [0., 1., 0., 1.]), [0., 0., 1., 1.]))
 
-        self.assertTrue(np.allclose(quaternion.apply_to_vector(q, [1., 0., 0., 1.]), [1., 0., 0., 1.]))
-        self.assertTrue(np.allclose(quaternion.apply_to_vector(mq, [1., 0., 0., 1.]), [1., 0., 0., 1.]))
+        self.assertTrue(np.allclose(quaternion.apply_to_vector(q, [0., 1., 0., 1.]), [0., 0., 1., 1.]))
+        self.assertTrue(np.allclose(quaternion.apply_to_vector(mq, [0., 1., 0., 1.]), [0., 0., 1., 1.]))
 
         np.testing.assert_almost_equal(q, mq, decimal=5)
         np.testing.assert_almost_equal(m, qm, decimal=5)
@@ -54,7 +54,6 @@ class test_matrix_quaternion(unittest.TestCase):
         q = quaternion.create(*[0.80087974, 0.03166748, 0.59114721,-0.09018753])
         m33 = matrix33.create_from_quaternion(q)
         q2 = quaternion.create_from_matrix(m33)
-        print(q, q2)
         self.assertTrue(np.allclose(q, q2))
 
         q3 = quaternion.create_from_matrix(m33.T)

--- a/tests/test_matrix33.py
+++ b/tests/test_matrix33.py
@@ -171,11 +171,25 @@ class test_matrix33(unittest.TestCase):
         expected = -vec
         self.assertTrue(np.allclose(result, expected))
 
+    def test_apply_to_vector_rotated_x2(self):
+        mat = matrix33.create_from_x_rotation(np.pi/2.)
+        vec = vector3.unit.y
+        result = matrix33.apply_to_vector(mat, vec)
+        expected = vector3.unit.z
+        self.assertTrue(np.allclose(result, expected))
+
     def test_apply_to_vector_rotated_y(self):
         mat = matrix33.create_from_y_rotation(np.pi)
         vec = vector3.unit.x
         result = matrix33.apply_to_vector(mat, vec)
         expected = -vec
+        self.assertTrue(np.allclose(result, expected))
+
+    def test_apply_to_vector_rotated_y2(self):
+        mat = matrix33.create_from_y_rotation(np.pi/2.)
+        vec = vector3.unit.x
+        result = matrix33.apply_to_vector(mat, vec)
+        expected = -vector3.unit.z
         self.assertTrue(np.allclose(result, expected))
 
     def test_apply_to_vector_rotated_z(self):
@@ -184,6 +198,14 @@ class test_matrix33(unittest.TestCase):
         result = matrix33.apply_to_vector(mat, vec)
         expected = -vec
         self.assertTrue(np.allclose(result, expected))
+
+    def test_apply_to_vector_rotated_z2(self):
+        mat = matrix33.create_from_z_rotation(np.pi/2.)
+        vec = vector3.unit.x
+        result = matrix33.apply_to_vector(mat, vec)
+        expected = vector3.unit.y
+        self.assertTrue(np.allclose(result, expected))
+
 
     def test_multiply_identity(self):
         m1 = matrix33.create_identity()

--- a/tests/test_matrix44.py
+++ b/tests/test_matrix44.py
@@ -400,15 +400,30 @@ class test_matrix44(unittest.TestCase):
         result = matrix44.apply_to_vector(mat, [0.,1.,0.])
         np.testing.assert_almost_equal(result, [0.,-1.,0.], decimal=5)
 
+    def test_apply_to_vector_x_rotation2(self):
+        mat = matrix44.create_from_x_rotation(np.pi/2.0)
+        result = matrix44.apply_to_vector(mat, [0.,1.,0.])
+        np.testing.assert_almost_equal(result, [0.,0.,1.], decimal=5)
+
     def test_apply_to_vector_y_rotation(self):
         mat = matrix44.create_from_y_rotation(np.pi)
         result = matrix44.apply_to_vector(mat, [1.,0.,0.])
         np.testing.assert_almost_equal(result, [-1.,0.,0.], decimal=5)
 
+    def test_apply_to_vector_y_rotation2(self):
+        mat = matrix44.create_from_y_rotation(np.pi/2.)
+        result = matrix44.apply_to_vector(mat, [1.,0.,0.])
+        np.testing.assert_almost_equal(result, [0.,0.,-1.], decimal=5)
+
     def test_apply_to_vector_z_rotation(self):
         mat = matrix44.create_from_z_rotation(np.pi)
         result = matrix44.apply_to_vector(mat, [1.,0.,0.])
         np.testing.assert_almost_equal(result, [-1.,0.,0.], decimal=5)
+
+    def test_apply_to_vector_z_rotation2(self):
+        mat = matrix44.create_from_z_rotation(np.pi/2.0)
+        result = matrix44.apply_to_vector(mat, [1.,0.,0.])
+        np.testing.assert_almost_equal(result, [0.,1.,0.], decimal=5)
 
     def test_apply_to_vector_with_translation(self):
         mat = matrix44.create_from_translation([2.,3.,4.])


### PR DESCRIPTION
## Purpose and Motivation
This pull request fixes #97 . The order of multiplication of the matrix and the vector in `apply_to_vector` was inverted. I added tests with 90 degrees rotations because the tests with rotation of 180 degrees do not highlight this type of error.

## Types of changes
- Bug fix
- Breaking change
