### PR TITLE
Fix #99: Fix ValueError in ray_intersect_aabb

### DIFF
--- a/pyrr/geometric_tests.py
+++ b/pyrr/geometric_tests.py
@@ -285,9 +285,10 @@ def ray_intersect_aabb(ray, aabb):
     t5 = (aabb[0,2] - ray[0,2]) * dir_fraction[ 2 ]
     t6 = (aabb[1,2] - ray[0,2]) * dir_fraction[ 2 ]
 
-
-    tmin = max(min(t1, t2), min(t3, t4), min(t5, t6))
-    tmax = min(max(t1, t2), max(t3, t4), max(t5, t6))
+    # the infinities are used here to eliminate NaNs that
+    # are generated when the ray sits on a boundary plane
+    tmin = max(-np.inf, min(t1, t2), min(t3, t4), min(t5, t6))
+    tmax = min(np.inf, max(t1, t2), max(t3, t4), max(t5, t6))
 
     # if tmax < 0, ray (line) is intersecting AABB
     # but the whole AABB is behind the ray start

--- a/tests/test_geometric_tests.py
+++ b/tests/test_geometric_tests.py
@@ -203,6 +203,12 @@ class test_geometric_tests(unittest.TestCase):
         result = gt.ray_intersect_aabb(r, a)
         self.assertEqual(result, None)
 
+    def test_ray_intersect_aabb_ray_on_a_boundary_plane(self):
+        a = np.array([[1.0,1.0,1.0], [4.0,4.0,4.0]])
+        r = np.array([[1.0,0.0,0.0], [0.0,1.0,1.0]])
+        result = gt.ray_intersect_aabb(r, a)
+        self.assertTrue(np.array_equal(result, [1.0, 1.0, 1.0]))
+
     def test_point_height_above_plane(self):
         pl = plane.create([0., 1., 0.], 1.)
         p = np.array([0., 1., 0.])


### PR DESCRIPTION
ray_intersect_aabb raised ValueError when the ray was on a boundary
plane. This was due to NaNs in t* values, produced by 0*inf=NaN.

Fixed by adding infinities in min/max tests, as suggested  in
https://tavianator.com/2015/ray_box_nan.html