### PR TITLE
apply_to_vector now operates on lists of vectors without throwing errors

### DIFF
--- a/pyrr/matrix33.py
+++ b/pyrr/matrix33.py
@@ -297,11 +297,12 @@ def apply_to_vector(mat, vec):
     :param numpy.array mat: The rotation / translation matrix.
         Can be a list of matrices.
     :param numpy.array vec: The vector to modify.
-        Can be a list of vectors.
+        Can be a numpy.array of vectors. ie. numpy.array([[x1,...], [x2,...], ...])
     :rtype: numpy.array
     :return: The vectors rotated by the specified matrix.
     """
-    if vec.size == 3:
+    size = vec.shape[len(vec.shape) - 1]
+    if size == 3:
         return np.dot(vec, mat)
     else:
         raise ValueError("Vector size unsupported")


### PR DESCRIPTION
I've tested this and I believe it fixes the issue regarding errors. As for performance, it takes the biggest hit  when converting vec3 to vec4 then renormalizing. I'm no expert, there might be a way to vectorize the vec3-mat4 steps more efficiently, however this is tested and the errors are gone.

benchmarks:
transform 1000000 3d vectors by a mat33:
Time elapsed: 0.01142809999999983 seconds, 87503609.52389416 vectors per second

transform 1000000 3d vectors by a mat44:
Time elapsed: 3.6538304000000004 seconds, 273685.39054248383 vectors per second

transform 1000000 4d vectors by a mat44:
Time elapsed: 0.012427100000000024 seconds, 80469296.93975247 vectors per second